### PR TITLE
Update GitHub action Publish-Docker-Github-Action

### DIFF
--- a/.github/workflows/seccompagent.yml
+++ b/.github/workflows/seccompagent.yml
@@ -14,7 +14,7 @@ jobs:
 
     - name: Build container and publish to Registry
       id: publish-registry
-      uses: elgohr/Publish-Docker-Github-Action@2.8
+      uses: elgohr/Publish-Docker-Github-Action@2.22
       with:
         # name: quay.io/kinvolk/seccompagent
         name: ${{ secrets.CONTAINER_REPO }}


### PR DESCRIPTION
With Publish-Docker-Github-Action v2.22, the container images are
correctly tagged as 'latest' when built from the 'main' branch. The
previous version only supported the 'master' branch.

https://github.com/elgohr/Publish-Docker-Github-Action/releases/tag/2.22

Signed-off-by: Alban Crequy <alban@kinvolk.io>
