### PR TITLE
Refactor registry to keep a state

### DIFF
--- a/pkg/handlers/error.go
+++ b/pkg/handlers/error.go
@@ -4,10 +4,35 @@ import (
 	"github.com/kinvolk/seccompagent/pkg/registry"
 
 	libseccomp "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	keyErrorSeq = "ErrorSeq"
 )
 
 func Error(err error) registry.HandlerFunc {
-	return func(fd libseccomp.ScmpFd, req *libseccomp.ScmpNotifReq) (result registry.HandlerResult) {
+	return func(filter registry.Filter, req *libseccomp.ScmpNotifReq) (result registry.HandlerResult) {
 		return registry.HandlerResultErrno(err)
+	}
+}
+
+func ErrorSeq() registry.HandlerFunc {
+	return func(filter registry.Filter, req *libseccomp.ScmpNotifReq) (result registry.HandlerResult) {
+		var seq *int
+		i := filter.Value(keyErrorSeq)
+		if i == nil {
+			newVal := 0
+			filter.SetValue(keyErrorSeq, &newVal)
+			seq = &newVal
+		} else {
+			seq = i.(*int)
+		}
+
+		*seq += 1
+		if *seq >= 5 {
+			*seq = 1
+		}
+		return registry.HandlerResultErrno(unix.Errno(*seq))
 	}
 }

--- a/pkg/kuberesolver/kuberesolver.go
+++ b/pkg/kuberesolver/kuberesolver.go
@@ -44,7 +44,7 @@ type PodContext struct {
 	Pid1 int
 }
 
-type KubeResolverFunc func(pod *PodContext, metadata map[string]string) *registry.Registry
+type KubeResolverFunc func(pod *PodContext, metadata map[string]string) registry.Filter
 
 func parseKV(metadata string) map[string]string {
 	vars := map[string]string{}
@@ -91,7 +91,7 @@ func KubeResolver(f KubeResolverFunc) (registry.ResolverFunc, error) {
 		return nil, errors.New("cannot create kubernetes client")
 	}
 
-	return func(state *specs.ContainerProcessState) *registry.Registry {
+	return func(state *specs.ContainerProcessState) registry.Filter {
 		vars := parseKV(state.Metadata)
 
 		podCtx := readAnnotations(state.State.Annotations)


### PR DESCRIPTION
This includes an example of handler that returns a different error each
time in a cycle. For this, we need to keep a state on the filter to
remember the previous error returned.
```
    f.AddHandler("chmod", handlers.ErrorSeq())
```
Signed-off-by: Alban Crequy <alban@kinvolk.io>
