### PR TITLE
docs: Clarify how to get containerd and kubernetes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ IMAGE_TAG=$(shell ./tools/image-tag)
 IMAGE_BRANCH_TAG=$(shell ./tools/image-tag branch)
 CONTAINER_REPO ?= quay.io/kinvolk/seccompagent
 
-.PHONY: seccompagent
 seccompagent:
 	$(GO_BUILD) -o seccompagent ./cmd/seccompagent
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,13 +23,31 @@ git checkout mauricio/seccomp-notify-listener-path
 make all
 ```
 
-Start containerd CRI:
+Get containerd:
 ```
-sudo PATH=/path/to/runc:$PATH _output/containerd --config myconfig.toml
+# Do this in $GOPATH/src/github.com/containerd/, it fails to build otherwise.
+git clone git@github.com:kinvolk/containerd.git
+cd containerd
+git checkout alban_seccomp_notify
+make all
+sudo make install
 ```
 
-Start Kubernetes with local-up-cluster.sh
+Start containerd CRI:
 ```
+# Make sure to not step over the system containerd (if you have it installed)
+# For that you can run:
+# 	bin/containerd config default  > test.toml
+# And modify the `root`, `state` and `grpc.address` paths to use unexistant
+# directories
+sudo PATH=/path/to/runc:$PATH bin/containerd --config test.toml
+```
+
+Clone kubernetes repo and start Kubernetes with local-up-cluster.sh, make sure
+to use Kubernetes >= 1.19:
+```
+# Make sure the endpoints match the values you configured for containerd
+# `grpc.address`
 export CONTAINER_RUNTIME_ENDPOINT=unix:///run/cricontainerd/containerd.sock
 export IMAGE_SERVICE_ENDPOINT=unix:///run/cricontainerd/containerd.sock
 export CONTAINER_RUNTIME=remote


### PR DESCRIPTION
Some docs improvements while I was playing with the seccomp agent. It took me some time to debug, since I hit _all_ the issues I describe here (using old k8s version, containerd hung in weird ways due to the config issue).

See commit messages for more info :)