### PR TITLE
Implement handler that terminate the container

### DIFF
--- a/docs/profiles/notify-dangerous.json
+++ b/docs/profiles/notify-dangerous.json
@@ -4,7 +4,7 @@
     "SCMP_ARCH_X86_64"
   ],
   "listenerPath": "/run/seccomp-agent.socket",
-  "listenerMetadata": "DEFAULT=kill-container",
+  "listenerMetadata": "DEFAULT_ACTION=kill-container",
   "syscalls": [
     {
       "action": "SCMP_ACT_NOTIFY",

--- a/docs/profiles/notify-dangerous.yaml
+++ b/docs/profiles/notify-dangerous.yaml
@@ -9,7 +9,7 @@ spec:
   architectures:
   - SCMP_ARCH_X86_64
   listenerPath: "/run/seccomp-agent.socket"
-  listenerMetadata: "DEFAULT=kill-container"
+  listenerMetadata: "DEFAULT_ACTION=kill-container"
 
   syscalls:
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -207,8 +207,8 @@ func notifHandler(reg *registry.Registry, seccompFile *os.File) {
 		}
 
 		if reg != nil {
-			handler, ok := reg.SyscallHandler[syscallName]
-			if ok {
+			handler := reg.Lookup(syscallName)
+			if handler != nil {
 				result := handler(fd, req)
 				if result.Intr {
 					log.WithFields(log.Fields{

--- a/pkg/handlers/default.go
+++ b/pkg/handlers/default.go
@@ -1,0 +1,51 @@
+// Copyright 2020-2022 Kinvolk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"os"
+
+	libseccomp "github.com/seccomp/libseccomp-golang"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
+	"github.com/kinvolk/seccompagent/pkg/registry"
+)
+
+func KillContainer(pid int) registry.HandlerFunc {
+	return func(fd libseccomp.ScmpFd, req *libseccomp.ScmpNotifReq) (result registry.HandlerResult) {
+		p, err := os.FindProcess(pid)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"pid": pid,
+			}).Error("cannot find process")
+			return registry.HandlerResultErrno(unix.EPERM)
+		}
+
+		if err := libseccomp.NotifIDValid(fd, req.ID); err != nil {
+			return registry.HandlerResultIntr()
+		}
+
+		err = p.Signal(os.Kill)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"pid": pid,
+			}).Error("cannot kill process")
+			return registry.HandlerResultErrno(unix.EPERM)
+		}
+
+		return registry.HandlerResultErrno(unix.EPERM)
+	}
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -58,6 +58,7 @@ func HandlerResultSuccess() HandlerResult {
 
 type Registry struct {
 	SyscallHandler map[string]HandlerFunc
+	DefaultHandler HandlerFunc
 }
 
 type ResolverFunc func(state *specs.ContainerProcessState) *Registry
@@ -68,6 +69,10 @@ func New() *Registry {
 	}
 }
 
-func (r *Registry) Add(name string, f HandlerFunc) {
-	r.SyscallHandler[name] = f
+func (r *Registry) Lookup(name string) HandlerFunc {
+	f, ok := r.SyscallHandler[name]
+	if ok {
+		return f
+	}
+	return r.DefaultHandler
 }


### PR DESCRIPTION
# Implement handler that terminate the container

When using `DEFAULT=kill-container` in the metadata, the seccomp agent will send a kill signal to the pid1 of the container. This effectively terminates the container.

## How to use

Use a SeccompProfile with the following:
```yaml
spec:
  defaultAction: SCMP_ACT_ALLOW
  architectures:
  - SCMP_ARCH_X86_64
  listenerPath: "/run/seccomp-agent.socket"
  listenerMetadata: "DEFAULT=kill-container"
  syscalls:
  - action: SCMP_ACT_NOTIFY
    names:
    - unshare
```

## Testing done

```
$ kubectl exec -ti mypod -- /bin/sh
# unshare -u
command terminated with exit code 137
$ kubectl get pod
NAME    READY   STATUS   RESTARTS   AGE
mypod   0/1     Error    0          18m
```