### PR TITLE
Dockerfile: Use floating latest versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
-# We need alpine edge for libseccomp-2.5.0
-
-FROM golang:1.17-alpine as builder
-RUN apk add alpine-sdk
-
-RUN \
-	sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories && \
-	apk add libseccomp libseccomp-dev
+FROM golang:1-alpine as builder
+RUN apk add alpine-sdk libseccomp libseccomp-dev
 
 RUN mkdir /build
 ADD . /build/
 WORKDIR /build
 RUN go build -o seccompagent ./cmd/seccompagent
 
-FROM alpine:edge
+FROM alpine:latest
 RUN apk add libseccomp
 COPY --from=builder /build/seccompagent /bin/seccompagent
 


### PR DESCRIPTION
Go 1.17 was dropped in https://github.com/docker-library/golang/pull/431 so this won't be getting updates.

Alpine 3.16 [contains](https://pkgs.alpinelinux.org/packages?name=libseccomp&branch=v3.16&repo=&arch=x86_64&maintainer=) libseccomp 2.5.2 so edge isn't need anymore.

Update to floating versions that will keep this updated.

## Testing done

```
make container-build
docker run quay.io/kinvolk/seccompagent:HEAD-a9c493f
[binary runs fine]
```