### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/seccompagent.yml
+++ b/.github/workflows/seccompagent.yml
@@ -14,7 +14,7 @@ jobs:
 
     - name: Build container and publish to Registry
       id: publish-registry
-      uses: elgohr/Publish-Docker-Github-Action@2.22
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         # name: quay.io/kinvolk/seccompagent
         name: ${{ secrets.CONTAINER_REPO }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore